### PR TITLE
Fix "Modification of non-creatable array value attempted, subscript -1" error and typos in README

### DIFF
--- a/README
+++ b/README
@@ -47,7 +47,7 @@ OPTIONS
         In which mode to run, see "MODES".
 
     "--dir", "-d"
-        The base direcotry of the backuops. It defaults to
+        The base directory of the backups. It defaults to
         "/var/backups/mysql/data/". This dirctory must exist. "innobackupex"
         then puts its default directory structure in there, so one ends up
         with a subdirectory for every single backup.
@@ -56,7 +56,7 @@ OPTIONS
         Which backup to restore. Defaults to the most recent one.
 
     "--out", "-o"
-        The directory wher to restore to.
+        The directory where to restore to.
 
     "--chown", "-c"
         A user (or uid) and optionaly a group (or gid) to "chmod" all files
@@ -87,7 +87,6 @@ HINTS and other STUFF
     *   When making a backup "innobackupex" is called with the arguments
 
         "--parallel=3"
-        "--compress"
         "--slave-info"
         "--safe-slave-backup"
         "--rsync"

--- a/xtrabackup-helper.pl
+++ b/xtrabackup-helper.pl
@@ -113,7 +113,7 @@ In which mode to run, see L</MODES>.
 
 =item C<--dir>, C<-d>
 
-The base direcotry of the backuops. It defaults to C</var/backups/mysql/data/>. This dirctory must exist.
+The base directory of the backups. It defaults to C</var/backups/mysql/data/>. This dirctory must exist.
 C<innobackupex> then puts its default directory structure in there, so one ends up with a subdirectory for
 every single backup.
 
@@ -123,7 +123,7 @@ Which backup to restore. Defaults to the most recent one.
 
 =item C<--out>, C<-o>
 
-The directory wher to restore to.
+The directory where to restore to.
 
 =item C<--chown>, C<-c>
 

--- a/xtrabackup-helper.pl
+++ b/xtrabackup-helper.pl
@@ -297,8 +297,6 @@ When making a backup C<innobackupex> is called with the arguments
     my $dir_progress = $dir . '/' . 'in_progress__' . $dt_str . '__';
     my $dir_finished = $dir . '/' . $dt_str;
 
-    my $base_dir = $dir . '/' . $backup_list[-1]->[0];
-
     my @cmd = (
         'innobackupex',
         '--parallel', 3, '--no-timestamp',
@@ -306,6 +304,7 @@ When making a backup C<innobackupex> is called with the arguments
         '--slave-info', '--rsync', '--defaults-extra-file', '/etc/mysql/debian.cnf'
     );
     if (!$make_full) {
+        my $base_dir = $dir . '/' . $backup_list[-1]->[0];
         push(@cmd, '--incremental', '--incremental-basedir', $base_dir);
     }
     push(@cmd, $dir_progress);


### PR DESCRIPTION
When the base directory of backups is empty xtrabackup-helper return the following error : 

> Modification of non-creatable array value attempted, subscript -1 at /usr/local/inikup/xtrabackup-helper.pl line 300.

This patch fix that and also some typos in README file.
